### PR TITLE
Prüfpunkt aus VS Code für Cloud-Agent-Sitzung

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,6 +1769,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Marked `fsevents` as dev-only in `package-lock.json`. This ensures the macOS-only watcher isn’t included in production installs and avoids unnecessary install attempts on non-macOS environments.

<sup>Written for commit 422787c009b471f66d0959a1493e4a4f94f45f92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

